### PR TITLE
Update 2015_07_18_100052_create_oauth_clients_table.php

### DIFF
--- a/database/migrations/2015_07_18_100052_create_oauth_clients_table.php
+++ b/database/migrations/2015_07_18_100052_create_oauth_clients_table.php
@@ -14,6 +14,7 @@ class CreateOauthClientsTable extends Migration
     {
         Schema::create('oauth_clients', function (BluePrint $table) {
             $table->string('id')->primary();
+            $table->string('name');
             $table->string('secret');
             $table->timestamps();
 


### PR DESCRIPTION
Add 'name' column to migrations as this column is referenced in Cribb\Oauth\ClientStorage.php